### PR TITLE
Remove `daysAheadOf` method

### DIFF
--- a/lib/src/utils/datetime_utils.dart
+++ b/lib/src/utils/datetime_utils.dart
@@ -48,14 +48,15 @@ extension DateTimeExtensions on DateTime {
   }
 
   bool isOnDailyIntervalFrom(DateTime startDate, int interval) {
-    final int numDaysApart = daysAheadOf(startDate);
+    final int numDaysApart = startDate.difference(this).inDays;
     return numDaysApart % interval == 0;
   }
 
   bool isOnWeeklyIntervalFrom(DateTime startDate, int interval) {
     final bool areSameWeekday = startDate.weekday == weekday;
-    final int weeksApart = (startDate.daysAheadOf(this) / 7).floor();
-    return areSameWeekday && weeksApart % interval == 0;
+    final int numDaysApart = startDate.difference(this).inDays;
+    final int numWeeksApart = (numDaysApart / 7).floor();
+    return areSameWeekday && numWeeksApart % interval == 0;
   }
 
   bool isOnMonthlyIntervalFrom(DateTime startDate, int interval) {
@@ -109,13 +110,6 @@ extension DateTimeExtensions on DateTime {
     }
 
     return monthsInBetween + ((yearsApart - 1) * 12);
-  }
-
-  int daysAheadOf(DateTime other) {
-    final int millisecondsApart =
-        millisecondsSinceEpoch - other.millisecondsSinceEpoch;
-    final int daysApart = (millisecondsApart / 1000 / 60 / 60 / 24).ceil();
-    return daysApart;
   }
 
   Iterable<DateTime> through(DateTime endDate, {bool inclusive = true}) {

--- a/test/datetime_extensions_test.dart
+++ b/test/datetime_extensions_test.dart
@@ -348,32 +348,6 @@ void main() {
       });
     });
 
-    group('the \'daysApartFrom\' function', () {
-      final DateTime today = DateTime.now().withZeroTime();
-
-      test('should work for dates that are zero days apart', () {
-        final DateTime testDate = DateTime(today.year, today.month, today.day);
-        final int daysApart = testDate.daysAheadOf(today);
-        expect(daysApart, equals(0));
-      });
-
-      test('should work for dates that are one day apart', () {
-        final DateTime testDate =
-            DateTime(today.year, today.month, today.day + 1);
-        final int daysApart = testDate.daysAheadOf(today);
-        expect(daysApart, equals(1));
-      });
-
-      test('should work for dates that are two or more days apart', () {
-        for (int i = 2; i <= 1000; i++) {
-          final DateTime testDate =
-              DateTime(today.year, today.month, today.day + i);
-          final int daysApart = testDate.daysAheadOf(today);
-          expect(daysApart, equals(i));
-        }
-      });
-    });
-
     group('the \'through\' function', () {
       test('should capture dates in the correct order', () {
         final DateTime startDate = DateTime(2020, 01, 01);


### PR DESCRIPTION
Removed the `daysAheadOf` method in favor of using Dart's built-in
`difference.inDays` method.

Ticket: 13

ps-id: e696edfd-b97a-4eef-8a82-3cd939d57f9c