### PR TITLE
Removed `toString` override from DateInterval

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -29,8 +29,6 @@ void main() {
 
   print(biWeekly.toString());
   // Every 2 weeks on Wednesday
-  print(biWeekly.toString(includeStartDate: true));
-  // Every 2 weeks on Wednesday, beginning on January 1, 2020
 
   print(biWeekly.includes(DateTime(2020, 01, 01))); // true
   print(biWeekly.includes(DateTime(2020, 01, 02))); // false
@@ -55,8 +53,6 @@ void main() {
 
   print(threeDays.toString());
   // Every 3 days
-  print(threeDays.toString(includeStartDate: true));
-  // Every 3 days, beginning on January 1, 2020
 
   print(threeDays.includes(DateTime(2020, 01, 01))); // true
   print(threeDays.includes(DateTime(2020, 01, 02))); // false
@@ -87,8 +83,6 @@ void main() {
 
   print(biAnnual.toString());
   // Every 6 months on the 1st
-  print(biAnnual.toString(includeStartDate: true));
-  // Every 6 months on the 1st, beginning on January 1, 2020
 
   print(biAnnual.includes(DateTime(2020, 01, 01))); // true
   print(biAnnual.includes(DateTime(2020, 07, 01))); // true

--- a/lib/src/date_interval.dart
+++ b/lib/src/date_interval.dart
@@ -1,5 +1,4 @@
 import 'intervals.dart';
-import 'package:intl/intl.dart' show DateFormat;
 import './utils/datetime_utils.dart';
 
 /// Defines a repetition interval.
@@ -91,37 +90,6 @@ class DateInterval {
       case Intervals.yearly:
         return targetDate.isOnYearlyIntervalFrom(startDate, period);
     }
-  }
-
-  /// Gets an English readable string representation of the interval pattern.
-  @override
-  String toString({bool includeStartDate = false}) {
-    String description = 'Every ';
-    switch (interval) {
-      case Intervals.once:
-        return 'Once on ${DateFormat.yMMMMd().format(startDate)}';
-      case Intervals.daily:
-        description += period > 1 ? '$period days' : 'day';
-        break;
-      case Intervals.weekly:
-        description += period > 1 ? '$period weeks' : 'week';
-        description += ' on ' + startDate.dayOfWeek;
-        break;
-      case Intervals.monthly:
-        description += period > 1 ? '$period months' : 'month';
-        description += ' on the ' + startDate.dayOfMonth;
-        break;
-      case Intervals.yearly:
-        description += period > 1 ? '$period years' : 'year';
-        description += ' on ${DateFormat.MMMMd().format(startDate)}';
-        break;
-    }
-
-    if (includeStartDate) {
-      description += ', beginning on ${DateFormat.yMMMMd().format(startDate)}';
-    }
-
-    return description;
   }
 
   bool _isAfterEndDate(DateTime date) =>


### PR DESCRIPTION
Removed the overridden `#toString` method due to its lack of support
for true internationalization and customization.

ps-id: f6950217-b95f-4917-8c57-b9686ed15eb0