### PR TITLE
Update version number

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_date_interval
 description: A package for configuring a repetition pattern, e.g. every other day, bi-weekly, monthly, etc. and finding dates that follow that pattern.
-version: 1.0.3
+version: 2.0.0
 homepage: https://github.com/andyhorn/flutter_date_interval
 
 environment:
@@ -19,4 +19,3 @@ dev_dependencies:
 
 # The following section is specific to Flutter.
 flutter:
-


### PR DESCRIPTION
Updated the version number to reflect the fact that there are significant
and breaking changes, including: Removed the `toString` override and the
`daysAheadOf` extension method.

ps-id: c9bfa881-b450-4187-99f8-905e435f483a