### PR TITLE
Add support for multiple days in one month

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 2.1.0
+
+<ul>
+    <li>
+        Added support for "additional days of the month," i.e. you can now represent "the 1st and 15th of the month" (or any arbitrary set of dates) in a single `DateInterval` object
+        <ul>
+            <li>
+                This can be controlled by setting a list of `int` values in the `additionalDaysOfTheMonth` property on the constructor
+            </li>
+            <li>
+                These "additional days" still abide by the "closest end date" rule
+            </li>
+        </ul>
+    </li>
+</ul>
+
 ## 2.0.0
 
 - Removed the overridden `toString` method as it wasn't really within the scope of this project and wasn't very useful

--- a/lib/src/date_interval.dart
+++ b/lib/src/date_interval.dart
@@ -11,6 +11,7 @@ class DateInterval {
     this.period = 1,
     this.interval = Intervals.once,
     Iterable<DateTime>? skipDates,
+    Iterable<int>? additionalDaysOfTheMonth,
   }) {
     if (period < 1) {
       throw ArgumentError.value(
@@ -25,6 +26,18 @@ class DateInterval {
         ? DateTime.now().withZeroTime()
         : startDate.withZeroTime();
     this.endDate = endDate?.withZeroTime();
+
+    additionalDaysOfTheMonth?.forEach((day) {
+      final date = DateTime(
+        this.startDate.year,
+        this.startDate.month,
+        day,
+      );
+
+      if (date.month == this.startDate.month) {
+        additionalDates.add(date);
+      }
+    });
   }
 
   /// The beginning of the interval. Determines the day-of-month (for monthly interval), day-of-week (for weekly interval).
@@ -41,6 +54,9 @@ class DateInterval {
 
   /// Any specific dates within the interval to skip that might otherwise be counted.
   final List<DateTime> skipDates = [];
+
+  /// Any additional "days of the month" that work alongside the start date.
+  final List<DateTime> additionalDates = [];
 
   /// Returns an [Iterable<DateTime>] of all valid dates between the
   /// configured [startDate] and the earliest of the configured
@@ -86,7 +102,10 @@ class DateInterval {
       case Intervals.weekly:
         return targetDate.isOnWeeklyIntervalFrom(startDate, period);
       case Intervals.monthly:
-        return targetDate.isOnMonthlyIntervalFrom(startDate, period);
+        final possibleDates = [startDate, ...additionalDates];
+        return possibleDates.any(
+          (date) => targetDate.isOnMonthlyIntervalFrom(date, period),
+        );
       case Intervals.yearly:
         return targetDate.isOnYearlyIntervalFrom(startDate, period);
     }

--- a/lib/src/utils/datetime_utils.dart
+++ b/lib/src/utils/datetime_utils.dart
@@ -58,7 +58,11 @@ extension DateTimeExtensions on DateTime {
     return areSameWeekday && weeksApart % interval == 0;
   }
 
-  bool isOnMonthlyIntervalFrom(DateTime startDate, int interval) {
+  bool isOnMonthlyIntervalFrom(
+    DateTime startDate,
+    int interval, [
+    Iterable<int>? additionalDates,
+  ]) {
     final bool isOnMonthlyInterval = monthsApartFrom(startDate) % interval == 0;
 
     if (!isOnMonthlyInterval) {
@@ -68,9 +72,13 @@ extension DateTimeExtensions on DateTime {
     final int lastDayOfThisMonth = DateTime(year, month + 1, 0).day;
     if (lastDayOfThisMonth < startDate.day) {
       return day == lastDayOfThisMonth;
-    } else {
-      return startDate.day == day;
     }
+
+    if (additionalDates?.isNotEmpty == true) {
+      return [startDate.day, ...additionalDates!].contains(day);
+    }
+
+    return startDate.day == day;
   }
 
   bool isOnYearlyIntervalFrom(DateTime startDate, int interval) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_date_interval
 description: A package for configuring a repetition pattern, e.g. every other day, bi-weekly, monthly, etc. and finding dates that follow that pattern.
-version: 2.0.0
+version: 2.1.0
 homepage: https://github.com/andyhorn/flutter_date_interval
 
 environment:

--- a/test/flutter_date_interval_test.dart
+++ b/test/flutter_date_interval_test.dart
@@ -362,6 +362,50 @@ void main() {
           expect(dates.every((date) => !interval.includes(date)), isTrue);
         });
 
+        group('with additional days of the month', () {
+          setUp(() {
+            startDate = DateTime(2020, 01, 01);
+            interval = DateInterval(
+              startDate: startDate,
+              interval: Intervals.monthly,
+              period: 2,
+              additionalDaysOfTheMonth: [15, 20],
+            );
+          });
+
+          test('includes all correct dates', () {
+            final List<DateTime> dates = [
+              DateTime(2020, 01, 01),
+              DateTime(2020, 01, 15),
+              DateTime(2020, 01, 20),
+              DateTime(2020, 03, 01),
+              DateTime(2020, 03, 15),
+              DateTime(2020, 03, 20),
+              DateTime(2020, 05, 01),
+              DateTime(2020, 05, 15),
+              DateTime(2020, 05, 20),
+            ];
+
+            expect(dates.every(interval.includes), isTrue);
+          });
+
+          test('does not include incorrect dates', () {
+            final List<DateTime> dates = [
+              DateTime(2020, 01, 02),
+              DateTime(2020, 02, 15),
+              DateTime(2020, 02, 20),
+              DateTime(2020, 03, 02),
+              DateTime(2020, 04, 15),
+              DateTime(2020, 04, 20),
+              DateTime(2020, 05, 02),
+              DateTime(2020, 06, 15),
+              DateTime(2020, 06, 20),
+            ];
+
+            expect(dates.every((date) => !interval.includes(date)), isTrue);
+          });
+        });
+
         group('end of the month', () {
           setUp(() {
             startDate = DateTime(2020, 01, 31);

--- a/test/flutter_date_interval_test.dart
+++ b/test/flutter_date_interval_test.dart
@@ -187,6 +187,45 @@ void main() {
             runTest();
           });
         });
+
+        group('with additional dates at the end of the month', () {
+          setUp(() {
+            dateInterval = DateInterval(
+              startDate: DateTime(2020, 01, 01),
+              interval: Intervals.monthly,
+              period: 1,
+              additionalDaysOfTheMonth: [15, 30],
+            );
+
+            expectedDates = [
+              DateTime(2020, 01, 01),
+              DateTime(2020, 01, 15),
+              DateTime(2020, 01, 30),
+              DateTime(2020, 02, 01),
+              DateTime(2020, 02, 15),
+              DateTime(2020, 02, 29),
+              DateTime(2020, 03, 01),
+              DateTime(2020, 03, 15),
+              DateTime(2020, 03, 30),
+              DateTime(2020, 04, 01),
+              DateTime(2020, 04, 15),
+              DateTime(2020, 04, 30),
+              DateTime(2020, 05, 01),
+              DateTime(2020, 05, 15),
+              DateTime(2020, 05, 30),
+              DateTime(2020, 06, 01),
+              DateTime(2020, 06, 15),
+              DateTime(2020, 06, 30),
+              DateTime(2020, 07, 01),
+            ];
+
+            result = dateInterval.getDatesThrough(DateTime(2020, 07)).toList();
+          });
+
+          test('should return the correct list of dates', () {
+            runTest();
+          });
+        });
       });
 
       group(Intervals.yearly, () {

--- a/test/flutter_date_interval_test.dart
+++ b/test/flutter_date_interval_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_date_interval/flutter_date_interval.dart';
 
 void main() {
-  group('$DateInterval', () {
+  group(DateInterval, () {
     group('#ctor', () {
       test('should not be able to set a period of less than 1', () {
         expect(() => DateInterval(period: 0), throwsArgumentError);
@@ -40,10 +40,15 @@ void main() {
       late List<DateTime> result;
 
       void runTest() {
-        expect(listEquals(result, expectedDates), isTrue);
+        expect(
+          listEquals(result, expectedDates),
+          isTrue,
+          reason:
+              'Expected $expectedDates\nbut got $result\nmissing ${expectedDates.toSet().difference(result.toSet())}',
+        );
       }
 
-      group('${Intervals.daily}', () {
+      group(Intervals.daily, () {
         setUp(() {
           dateInterval = DateInterval(
             interval: Intervals.daily,
@@ -74,7 +79,7 @@ void main() {
         });
       });
 
-      group('${Intervals.weekly}', () {
+      group(Intervals.weekly, () {
         setUp(() {
           dateInterval = DateInterval(
             interval: Intervals.weekly,
@@ -99,7 +104,7 @@ void main() {
         });
       });
 
-      group('${Intervals.monthly}', () {
+      group(Intervals.monthly, () {
         setUp(() {
           dateInterval = DateInterval(
             startDate: DateTime(2020, 01, 01),
@@ -120,41 +125,71 @@ void main() {
         test('should return the correct list of dates', () {
           runTest();
         });
-      });
 
-      group('${Intervals.monthly} at the end of the month', () {
-        setUp(() {
-          dateInterval = DateInterval(
-            startDate: DateTime(2020, 01, 31),
-            interval: Intervals.monthly,
-            period: 1,
-          );
+        group('at the end of the month', () {
+          setUp(() {
+            dateInterval = DateInterval(
+              startDate: DateTime(2020, 01, 31),
+              interval: Intervals.monthly,
+              period: 1,
+            );
 
-          expectedDates = [
-            DateTime(2020, 01, 31),
-            DateTime(2020, 02, 29),
-            DateTime(2020, 03, 31),
-            DateTime(2020, 04, 30),
-            DateTime(2020, 05, 31),
-            DateTime(2020, 06, 30),
-            DateTime(2020, 07, 31),
-            DateTime(2020, 08, 31),
-            DateTime(2020, 09, 30),
-            DateTime(2020, 10, 31),
-            DateTime(2020, 11, 30),
-            DateTime(2020, 12, 31),
-          ];
+            expectedDates = [
+              DateTime(2020, 01, 31),
+              DateTime(2020, 02, 29),
+              DateTime(2020, 03, 31),
+              DateTime(2020, 04, 30),
+              DateTime(2020, 05, 31),
+              DateTime(2020, 06, 30),
+              DateTime(2020, 07, 31),
+              DateTime(2020, 08, 31),
+              DateTime(2020, 09, 30),
+              DateTime(2020, 10, 31),
+              DateTime(2020, 11, 30),
+              DateTime(2020, 12, 31),
+            ];
 
-          result =
-              dateInterval.getDatesThrough(DateTime(2021, 01, 01)).toList();
+            result =
+                dateInterval.getDatesThrough(DateTime(2021, 01, 01)).toList();
+          });
+
+          test('should return the correct list of dates', () {
+            runTest();
+          });
         });
 
-        test('should return the correct list of dates', () {
-          runTest();
+        group('with additional dates', () {
+          setUp(() {
+            dateInterval = DateInterval(
+              startDate: DateTime(2020, 01, 01),
+              interval: Intervals.monthly,
+              period: 2,
+              additionalDaysOfTheMonth: [10, 15],
+            );
+
+            expectedDates = [
+              DateTime(2020, 01, 01),
+              DateTime(2020, 01, 10),
+              DateTime(2020, 01, 15),
+              DateTime(2020, 03, 01),
+              DateTime(2020, 03, 10),
+              DateTime(2020, 03, 15),
+              DateTime(2020, 05, 01),
+              DateTime(2020, 05, 10),
+              DateTime(2020, 05, 15),
+              DateTime(2020, 07, 01),
+            ];
+
+            result = dateInterval.getDatesThrough(DateTime(2020, 07)).toList();
+          });
+
+          test('should return the correct list of dates', () {
+            runTest();
+          });
         });
       });
 
-      group('${Intervals.yearly}', () {
+      group(Intervals.yearly, () {
         setUp(() {
           dateInterval = DateInterval(
             startDate: DateTime(2020, 01, 15),
@@ -175,33 +210,33 @@ void main() {
         test('should return the correct list of dates', () {
           runTest();
         });
-      });
 
-      group('${Intervals.yearly} on leap years', () {
-        setUp(() {
-          dateInterval = DateInterval(
-            startDate: DateTime(2020, 02, 29),
-            interval: Intervals.yearly,
-            period: 1,
-          );
+        group('on leap years', () {
+          setUp(() {
+            dateInterval = DateInterval(
+              startDate: DateTime(2020, 02, 29),
+              interval: Intervals.yearly,
+              period: 1,
+            );
 
-          expectedDates = [
-            DateTime(2020, 02, 29),
-            DateTime(2024, 02, 29),
-            DateTime(2028, 02, 29),
-          ];
+            expectedDates = [
+              DateTime(2020, 02, 29),
+              DateTime(2024, 02, 29),
+              DateTime(2028, 02, 29),
+            ];
 
-          result = dateInterval.getDatesThrough(DateTime(2030)).toList();
-        });
+            result = dateInterval.getDatesThrough(DateTime(2030)).toList();
+          });
 
-        test('should return the correct list of dates', () {
-          runTest();
+          test('should return the correct list of dates', () {
+            runTest();
+          });
         });
       });
     });
 
     group('#includes', () {
-      group('${Intervals.once}', () {
+      group(Intervals.once, () {
         final DateTime date = DateTime(2020, 01, 01);
         final DateInterval interval = DateInterval(
           startDate: date,
@@ -221,7 +256,7 @@ void main() {
         });
       });
 
-      group('${Intervals.daily}', () {
+      group(Intervals.daily, () {
         final DateTime date = DateTime(2020, 01, 01);
         final DateTime endDate = DateTime(2020, 01, 15);
         final DateInterval interval = DateInterval(
@@ -273,7 +308,7 @@ void main() {
         });
       });
 
-      group('${Intervals.weekly}', () {
+      group(Intervals.weekly, () {
         late DateTime startDate;
         late DateTime endDate;
         late DateInterval interval;
@@ -325,7 +360,7 @@ void main() {
         });
       });
 
-      group('${Intervals.monthly}', () {
+      group(Intervals.monthly, () {
         late DateTime startDate;
         late DateInterval interval;
 
@@ -430,7 +465,7 @@ void main() {
         });
       });
 
-      group('${Intervals.yearly}', () {
+      group(Intervals.yearly, () {
         late DateTime startDate;
         late DateInterval interval;
 


### PR DESCRIPTION
Closes #36 

Adds support for setting multiple days within a monthly interval, enabling representations such as "the 1st **and** 15th of every month."